### PR TITLE
IBSjsonrpcClient : fixed the issue on using `timeout` property.

### DIFF
--- a/json-rpc/sample-code/php/ibs-jsonrpc-client.php
+++ b/json-rpc/sample-code/php/ibs-jsonrpc-client.php
@@ -26,7 +26,7 @@ class IBSjsonrpcClient {
         $this->timeout = $timeout;
     }
 
-    function sendRequest($server_method, $params_arr, $timeout=1800){
+    function sendRequest($server_method, $params_arr){
         /*
             Send request to $server_method, with parameters $params_arr
             $server_method: method to call ex admin.addNewAdmin
@@ -35,7 +35,7 @@ class IBSjsonrpcClient {
         $params_arr["auth_name"] = $this->auth_name;
         $params_arr["auth_pass"] = $this->auth_pass;
         $params_arr["auth_type"] = $this->auth_type;
-        $response = $this->client->send($server_method, $params_arr, $timeout);
+        $response = $this->client->send($server_method, $params_arr, $this->timeout);
         $result = $this->__returnResponse($response);
         unset($response);
         return $result;

--- a/json-rpc/sample-code/php/ibs-jsonrpc-client.php
+++ b/json-rpc/sample-code/php/ibs-jsonrpc-client.php
@@ -908,5 +908,3 @@ class IBSjsonrpcClient {
 }
 
 ?>
-
-


### PR DESCRIPTION

1. Forced all methods in "IBSjsonrpcClient" class to use the timeout that is defined by the contructor.
2. Removed Tailing empty lines.
    Because these lines affect on the result of any other script that use this library.